### PR TITLE
Remove "Disallow: /content[$]" from robots.txt

### DIFF
--- a/environments/prod/group_vars/all/robots_txt.yml
+++ b/environments/prod/group_vars/all/robots_txt.yml
@@ -11,8 +11,6 @@ robots_txt:
     - legacy.cnx.org
     - /lenses
     - /browse_content
-    - /content/
-    - /content$
     - /*/pdf$
     - /*/epub$
     - /*/complete$


### PR DESCRIPTION
requirement for SEO