### PR TITLE
Use rhaptos.cnxmlutils master branch on katalyst01

### DIFF
--- a/environments/katalyst01/files/archive-requirements.txt
+++ b/environments/katalyst01/files/archive-requirements.txt
@@ -2,7 +2,7 @@ db-migrator==1.1.0
 
 -e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 -e git+https://github.com/openstax/cnx-transforms.git#egg=cnx-transforms
--e git+https://github.com/Connexions/rhaptos.cnxmlutils.git@fix-nested-terms-in-glossary#egg=rhaptos.cnxmlutils
+-e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db


### PR DESCRIPTION
In katalyst01 archive-requirements.txt, the
"fix-nested-terms-in-glossary" branch was used rhaptos.cnxmlutils.  When
I tried to `pip install -r archive-requirements.txt`, I got this error:

```
karen@yachiyo:~/src/cnx-deploy$ ./py2/bin/pip install -r environments/katalyst01/files/archive-requirements.txt
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting db-migrator==1.1.0 (from -r environments/katalyst01/files/archive-requirements.txt (line 1))
Obtaining cnx-query-grammar from git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar (from -r environments/katalyst01/files/archive-requirements.txt (line 3))
  Cloning https://github.com/Connexions/cnx-query-grammar.git to ./py2/src/cnx-query-grammar
Obtaining cnx-transforms from git+https://github.com/openstax/cnx-transforms.git#egg=cnx-transforms (from -r environments/katalyst01/files/archive-requirements.txt (line 4))
  Cloning https://github.com/openstax/cnx-transforms.git to ./py2/src/cnx-transforms
Obtaining rhaptos.cnxmlutils from git+https://github.com/Connexions/rhaptos.cnxmlutils.git@fix-nested-terms-in-glossary#egg=rhaptos.cnxmlutils (from -r environments/katalyst01/files/archive-requirements.txt (line 5))
  Cloning https://github.com/Connexions/rhaptos.cnxmlutils.git (to revision fix-nested-terms-in-glossary) to ./py2/src/rhaptos.cnxmlutils
  Did not find branch or tag 'fix-nested-terms-in-glossary', assuming revision or ref.
error: pathspec 'fix-nested-terms-in-glossary' did not match any file(s) known to git.
Command "git checkout -q fix-nested-terms-in-glossary" failed with error code 1 in /home/karen/src/cnx-deploy/py2/src/rhaptos.cnxmlutils
```

The branch does not exist anymore because it has been merged.

We can fix this by just using the master branch instead.