### PR TITLE
Fix Google redirect when arrived at non-versioned url

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -406,7 +406,7 @@ sub vcl_backend_response {
 
             # Redirect search traffic from archive.cnx.org URLs to the corresponding pages on CNX
             # See: https://github.com/openstax/cnx/issues/209
-            if (bereq.http.host ~ "archive" && bereq.url ~ "^/contents/" && bereq.http.Referer ~ "google") {
+            if (bereq.http.host ~ "archive" && bereq.url ~ "^/contents/.*@.*" && bereq.http.Referer ~ "google") {
               set beresp.http.status = 302;
               set beresp.http.Location = regsub(beresp.http.Link, "^<(https://.*)>.*Canonical.", "\1");
               set beresp.http.X-Varnish-Status = "uncacheable - redirected google";


### PR DESCRIPTION
If/when the Google result is to a non-versioned URL, the redirect does not include the canonical header, and yet, my previous code (an `if` statement) expected it to be there. The redirect is simply to the versioned URL.

This PR expects the requested URL to be the versioned one which does include the canonical header once archive has added it.

Before this change/PR (please ignore the extra headers for dev/testing purposes):

```
iii > curl https://archive-dev.cnx.org/contents/fea3130c-6e57-41b2-a00f-0267ffae273c -ILXGET -e "google"
HTTP/1.1 302 Found
Access-Control-Allow-Headers: origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: max-age=60, public
Content-Length: 216
Content-Type: text/html; charset=UTF-8
Date: Fri, 15 Mar 2019 18:50:11 GMT
Etag: "1B2M2Y8AsgTpgAmY7PhCfg"
Server: waitress
X-Varnish-Canonical-Url: 
X-Varnish-Status: uncacheable - redirect google
Location: 
X-Varnish-THREE-CODITIONS: all true
X-Varnish-Landed: landed in contents/
X-Varnish-Refered: refered by google
X-Varnish-Archive-Req: woohoo! requested archive
X-Varnish-Host-Was: archive-dev.cnx.org
X-Varnish-THE-Canonical-Url: 
X-Varnish-Backend: dev00_archive0
X-Varnish-Ttl: 60.000
X-Varnish: 33831
Age: 0
Via: 1.1 varnish-v4
X-Varnish-Cache: MISS
Strict-Transport-Security: max-age=16000000
```

After this change/PR, this is the result from requesting a non-versioned URL  (please ignore the extra headers for dev/testing purposes):

```
[03/15 13:58:44] [redirect_google_away_from_archive] /Users/bryaneli/openstax/cnx-deploy
iii > curl https://archive-dev.cnx.org/contents/fea3130c-6e57-41b2-a00f-0267ffae273c -ILXGET -e "google"
HTTP/1.1 302 Found
Access-Control-Allow-Headers: origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: max-age=60, public
Content-Length: 216
Content-Type: text/html; charset=UTF-8
Date: Fri, 15 Mar 2019 19:03:06 GMT
Etag: "1B2M2Y8AsgTpgAmY7PhCfg"
Location: https://archive-dev.cnx.org/contents/fea3130c-6e57-41b2-a00f-0267ffae273c@5
Server: waitress
X-Varnish-Status: cacheable - Cache-Control in backend response
X-Varnish-Backend: dev00_archive0
X-Varnish-Ttl: 60.000
X-Varnish: 1917
Age: 0
Via: 1.1 varnish-v4
X-Varnish-Cache: MISS
Strict-Transport-Security: max-age=16000000

HTTP/1.1 302 Found
Access-Control-Allow-Headers: origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: max-age=31536000, public
Content-Length: 9292
Content-Type: application/json
Date: Fri, 15 Mar 2019 19:03:06 GMT
Etag: "OfLsiBKeGFPUcyHtbkq/Zg"
Expires: Sat, 14 Mar 2020 19:03:06 GMT
Link: <https://dev.cnx.org/contents/303800f3-07f3-44d5-a12c-49e93e8948c5:fea3130c-6e57-41b2-a00f-0267ffae273c/Program-Design> ;rel="Canonical"
Server: waitress
X-Varnish-Canonical-Url: https://dev.cnx.org/contents/303800f3-07f3-44d5-a12c-49e93e8948c5:fea3130c-6e57-41b2-a00f-0267ffae273c/Program-Design
X-Varnish-Status: uncacheable - redirect google
Location: https://dev.cnx.org/contents/303800f3-07f3-44d5-a12c-49e93e8948c5:fea3130c-6e57-41b2-a00f-0267ffae273c/Program-Design
X-Varnish-Backend: dev00_archive0
X-Varnish-Ttl: 60.000
X-Varnish: 131089
Age: 0
Via: 1.1 varnish-v4
X-Varnish-Cache: MISS
Strict-Transport-Security: max-age=16000000

HTTP/1.1 200 OK
Server: nginx
Date: Fri, 15 Mar 2019 19:03:06 GMT
Content-Type: text/html
Last-Modified: Thu, 20 Dec 2018 16:00:15 GMT
Vary: Accept-Encoding
Expires: Fri, 15 Mar 2019 19:03:05 GMT
Cache-Control: no-cache
X-Varnish-Status: uncacheable - ttl <= 0
X-Varnish-Backend: webview
X-Varnish-Ttl: 60.000
X-Varnish: 131092
Age: 0
Via: 1.1 varnish-v4
ETag: W/"5c1bbc8f-2e3"
X-Varnish-Cache: MISS
Accept-Ranges: bytes
Content-Length: 1524
Strict-Transport-Security: max-age=16000000
```