### PR TITLE
Creates static configuration for redirects from CNX to REX

### DIFF
--- a/.update/do.py
+++ b/.update/do.py
@@ -1,0 +1,131 @@
+import click
+import requests
+from pathlib import Path
+
+from cnxcommon import ident_hash
+
+
+here = Path(__file__).parent
+CNX_HOST = 'archive.cnx.org'
+MAP_FILEPATH = here.resolve().parent / 'roles/webview/files/etc/nginx/uri-maps/rex-uris.map'
+
+
+def get_rex_release_json_url(host):
+    return f'https://{host}/rex/release.json'
+
+
+def get_book_slug(book_id):
+    url = (
+        "https://openstax.org/apps/cms/api/v2/pages/"
+        f"?type=books.Book&fields=cnx_id&format=json&cnx_id={book_id}"
+    )
+    book = requests.get(url).json()['items'][0]
+    return book['meta']['slug']
+
+
+def flatten_tree(tree):
+    """Flatten a tree to a linear sequence of values."""
+    yield dict([
+        (k, v)
+        for k, v in tree.items()
+        if k != 'contents'
+    ])
+    if 'contents' in tree:
+        for x in tree['contents']:
+            for y in flatten_tree(x):
+                yield y
+
+
+def rex_uri(book, page):
+    if page is None:
+        uri = f'/books/{book}'
+    else:
+        uri = f'/books/{book}/pages/{page}'
+    return uri
+
+
+def cnx_uri_regex(book, page):
+    if page is None:
+        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?(/[-%\w\d]+)?$"
+    else:
+        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?:({page['id']}|{page['short_id']})(@[\d]+)?(/[-%\w\d]+)?$"
+    return uri_regex
+
+
+def expand_tree_node(node):
+    result = {
+        'slug': node['slug'],
+        'title': node['title'],
+    }
+    result['id'], result['version'] = ident_hash.split_ident_hash(node['id'])
+    try:
+        # We raise an error for this... It maybe makes sense for the application of it in archive?
+        ident_hash.split_ident_hash(node['shortId'])
+    except ident_hash.IdentHashShortId as exc:
+        result['short_id'] = exc.id
+    return result
+
+
+def get_book_nodes(book_id):
+    """Returns a list of nodes in a book's tree."""
+    resp = requests.get(f'https://{CNX_HOST}/contents/{book_id}.json')
+    metadata = resp.json()
+    book_short_id = metadata
+    for x in flatten_tree(metadata['tree']):
+        yield expand_tree_node(x)
+
+
+def generate_nginx_uri_mappings(book):
+    """\
+    This creates the nginx uri map to be used inside the nginx
+    configuration's `map` block.
+
+    """
+    nodes = list(get_book_nodes(book))
+    book_node = nodes[0]
+    book_slug = get_book_slug(book)
+
+    uri_mappings = [
+        # Book URL redirects to the first page of the REX book
+        (cnx_uri_regex(book_node, None), rex_uri(book_slug, nodes[1]['slug']),)
+    ]
+    for node in nodes[1:]:  # skip the book
+        uri_mappings.append(
+            (cnx_uri_regex(book_node, node),
+             rex_uri(book=book_slug, page=node['slug']),
+            )
+        )
+    return uri_mappings
+
+
+def write_nginx_map(uri_map, out):
+    for orig_uri, dest_uri in uri_map:
+        out.write(f'~{orig_uri}    {dest_uri};\n'.encode())
+
+
+@click.command()
+@click.argument('rex-host')
+def update_rex_redirects(rex_host):
+    release_json_url = get_rex_release_json_url(rex_host)
+    release_data = requests.get(release_json_url).json()
+    books = [book for book in release_data['books']]
+    if MAP_FILEPATH.exists():
+        click.echo("Removing existing map")
+        MAP_FILEPATH.unlink()
+    for book in books:
+        click.echo(f"Write entries for {book}.")
+        book_uri_map = generate_nginx_uri_mappings(book)
+        with MAP_FILEPATH.open('ab') as fb:
+            write_nginx_map(book_uri_map, out=fb)
+
+
+@click.group()
+def main():
+    pass
+
+
+main.add_command(update_rex_redirects)
+
+
+if __name__ == '__main__':
+    main()

--- a/.update/requirements.txt
+++ b/.update/requirements.txt
@@ -1,0 +1,3 @@
+click
+cnx-common
+requests

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ ansible-playbook -i environments/$ENV/inventory main.yml
 
 Please see the environment's README for specific details.
 
+## Updating generated content
+
+This project has generatated content in it. By running the `python3 .update/do.py` you are updating that content. It's your responsibilty to commit, push and create a pull request for the changes.
+
+```sh
+pip3 install --upgrade -r .update/requirements.txt
+python3 .update/do.py update-rex-redirects $REX_HOST
+```
+
 ## Troubleshooting
 
 1. Search through the issues on github. If you find the issue, check for a resolution. If there is no resolution, let your voice be heard and wait for a reply.

--- a/environments/autodev01/group_vars/all/vars.yml
+++ b/environments/autodev01/group_vars/all/vars.yml
@@ -68,3 +68,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/content01/group_vars/all/vars.yml
+++ b/environments/content01/group_vars/all/vars.yml
@@ -62,3 +62,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/content02/group_vars/all/vars.yml
+++ b/environments/content02/group_vars/all/vars.yml
@@ -62,3 +62,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/content03/group_vars/all/vars.yml
+++ b/environments/content03/group_vars/all/vars.yml
@@ -62,3 +62,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/content04/group_vars/all/vars.yml
+++ b/environments/content04/group_vars/all/vars.yml
@@ -62,3 +62,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/content05/group_vars/all/vars.yml
+++ b/environments/content05/group_vars/all/vars.yml
@@ -62,3 +62,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -76,3 +76,4 @@ nfs_server_for_varnish_logs: dev00.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/easyvm1/group_vars/all/vars.yml
+++ b/environments/easyvm1/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/easyvm2/group_vars/all/vars.yml
+++ b/environments/easyvm2/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/easyvm3/group_vars/all/vars.yml
+++ b/environments/easyvm3/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/easyvm4/group_vars/all/vars.yml
+++ b/environments/easyvm4/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/easyvm5/group_vars/all/vars.yml
+++ b/environments/easyvm5/group_vars/all/vars.yml
@@ -70,3 +70,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/katalyst01/group_vars/all/vars.yml
+++ b/environments/katalyst01/group_vars/all/vars.yml
@@ -68,3 +68,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/legacy-staging/group_vars/all/vars.yml
+++ b/environments/legacy-staging/group_vars/all/vars.yml
@@ -51,3 +51,4 @@ cms_domain: openstax.org
 
 accounts_disable_verify_ssl: yes
 accounts_stub: yes
+rex_domain: rex-web.herokuapp.com

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -93,3 +93,4 @@ google_site_verification_filename: "{{ vault_google_site_verification_filename }
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -81,3 +81,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -92,3 +92,4 @@ nfs_connections: "{{ vault_nfs_connections }}"
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/tea/group_vars/all/vars.yml
+++ b/environments/tea/group_vars/all/vars.yml
@@ -58,3 +58,4 @@ nfs_server_for_varnish_logs: tea00.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/environments/vendor-staging01/group_vars/all/vars.yml
+++ b/environments/vendor-staging01/group_vars/all/vars.yml
@@ -58,3 +58,4 @@ nfs_server_for_files2: "{{ _host_prefix }}.cnx.org"
 nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com

--- a/roles/nginx/files/etc/nginx/nginx.conf
+++ b/roles/nginx/files/etc/nginx/nginx.conf
@@ -26,6 +26,9 @@ http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 
+	# To allow for a larger `map` size.
+	map_hash_bucket_size 2048;
+
 	##
 	# SSL Settings
 	##

--- a/roles/webview/tasks/webview.yml
+++ b/roles/webview/tasks/webview.yml
@@ -81,6 +81,27 @@
   notify:
     - reload nginx
 
+- name: create the uri-maps directory
+  become: yes
+  file:
+    path: /etc/nginx/uri-maps
+    state: directory
+    recurse: yes
+    owner: root
+    group: root
+    mode: 0644
+
+- name: copy main nginx config
+  become: yes
+  copy:
+    src: etc/nginx/uri-maps/rex-uris.map
+    dest: /etc/nginx/uri-maps/rex-uris.map
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - reload nginx
+
 - name: enable the webview nginx site
   become: yes
   file:

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -1,3 +1,8 @@
+map $request_uri $rex_uri {
+    default "no-match";
+    include /etc/nginx/uri-maps/rex-uris.map;
+}
+
 server {
     listen          8081;
     server_name     {{ frontend_domain }};
@@ -5,6 +10,10 @@ server {
     index           index.html;
     try_files       $uri $uri/ /index.html;
     expires         -1;
+
+    if ($rex_uri != "no-match") {
+        return 302 https://{{ rex_domain }}$rex_uri;
+    }
 
     location /ping {
         add_header Content-Length 0;


### PR DESCRIPTION
See openstax/cnx#343 for details on why this has been implemented.

This has been implemented as a static build because looking up this info on ever deploy would be error-prone. The idea is to generate it once, check it in, and use it multiple times.

The REX host portion of this is configuration so that it can point at various environment instances of this service.