### PR TITLE
Create a feature flag for the REX redirects

### DIFF
--- a/environments/autodev01/group_vars/all/vars.yml
+++ b/environments/autodev01/group_vars/all/vars.yml
@@ -72,3 +72,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/content01/group_vars/all/vars.yml
+++ b/environments/content01/group_vars/all/vars.yml
@@ -63,3 +63,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/content02/group_vars/all/vars.yml
+++ b/environments/content02/group_vars/all/vars.yml
@@ -63,3 +63,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/content03/group_vars/all/vars.yml
+++ b/environments/content03/group_vars/all/vars.yml
@@ -63,3 +63,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/content04/group_vars/all/vars.yml
+++ b/environments/content04/group_vars/all/vars.yml
@@ -63,3 +63,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/content05/group_vars/all/vars.yml
+++ b/environments/content05/group_vars/all/vars.yml
@@ -63,3 +63,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -77,3 +77,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/easyvm1/group_vars/all/vars.yml
+++ b/environments/easyvm1/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/easyvm2/group_vars/all/vars.yml
+++ b/environments/easyvm2/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/easyvm3/group_vars/all/vars.yml
+++ b/environments/easyvm3/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/easyvm4/group_vars/all/vars.yml
+++ b/environments/easyvm4/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/easyvm5/group_vars/all/vars.yml
+++ b/environments/easyvm5/group_vars/all/vars.yml
@@ -71,3 +71,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/katalyst01/group_vars/all/vars.yml
+++ b/environments/katalyst01/group_vars/all/vars.yml
@@ -69,3 +69,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/legacy-staging/group_vars/all/vars.yml
+++ b/environments/legacy-staging/group_vars/all/vars.yml
@@ -52,3 +52,4 @@ cms_domain: openstax.org
 accounts_disable_verify_ssl: yes
 accounts_stub: yes
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -94,3 +94,4 @@ blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -82,3 +82,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: true

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -93,3 +93,4 @@ blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/tea/group_vars/all/vars.yml
+++ b/environments/tea/group_vars/all/vars.yml
@@ -59,3 +59,4 @@ webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/environments/vendor-staging01/group_vars/all/vars.yml
+++ b/environments/vendor-staging01/group_vars/all/vars.yml
@@ -59,3 +59,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -11,9 +11,11 @@ server {
     try_files       $uri $uri/ /index.html;
     expires         -1;
 
+    {% if rex_redirects_enabled %}
     if ($rex_uri != "no-match") {
         return 302 https://{{ rex_domain }}$rex_uri;
     }
+    {% endif %}
 
     location /ping {
         add_header Content-Length 0;


### PR DESCRIPTION
This adds a setting to conditionally enable the REX redirects per environment. We'll probably never want to enable the redirects on vendor environments and we can't enable the redirects on staging or production until the release of REX later this year.

This will disable the REX redirects for all environments except `qa`, for now. 