### PR TITLE
Add rex variables to the vm environment

### DIFF
--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -62,5 +62,7 @@ nfs_server_for_varnish_logs: local.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+rex_domain: rex-web.herokuapp.com
+rex_redirects_enabled: false
 
 venvs_owner: "{{ ansible_user_id }}"

--- a/roles/cnx_database/tasks/plpython_imports.yml
+++ b/roles/cnx_database/tasks/plpython_imports.yml
@@ -47,7 +47,7 @@
     path: "/var/cnx/venvs"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of venvs directory
   become: yes
@@ -55,11 +55,11 @@
     path: "/var/cnx/venvs"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: create the archive virtualenv
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name: pip
     virtualenv: "/var/cnx/venvs/archive"
@@ -89,7 +89,7 @@
 
 - name: install archive
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"

--- a/roles/press_common/tasks/main.yml
+++ b/roles/press_common/tasks/main.yml
@@ -36,7 +36,7 @@
     path: "/var/cnx/venvs"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of venvs directory
   become: yes
@@ -44,11 +44,11 @@
     path: "/var/cnx/venvs"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: create the venv
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   command: "python3.6 -m venv /var/cnx/venvs/press"
 
 # +++
@@ -66,7 +66,7 @@
     path: "/var/cnx/apps"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of apps directory
   become: yes
@@ -74,11 +74,11 @@
     path: "/var/cnx/apps"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: checkout codebase
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   git:
     repo: "https://github.com/Connexions/cnx-press.git"
     dest: "/var/cnx/apps/press"
@@ -105,7 +105,7 @@
 
 - name: upgrade pip
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name: pip
     virtualenv: "/var/cnx/venvs/press"
@@ -113,7 +113,7 @@
 
 - name: install pinned dependencies
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   when: pinned_reqs.stat.exists
   pip:
     virtualenv: "/var/cnx/venvs/press"
@@ -124,7 +124,7 @@
 
 - name: install latest dependencies
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   when: not pinned_reqs.stat.exists
   pip:
     virtualenv: "/var/cnx/venvs/press"
@@ -140,7 +140,7 @@
 # This is currently only a cnx-deploy deployment dependency.
 - name: install deployment dependencies
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     virtualenv: "/var/cnx/venvs/press"
     name: "waitress"

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -38,7 +38,7 @@
     path: "/var/cnx/venvs"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of venvs directory
   become: yes
@@ -46,11 +46,11 @@
     path: "/var/cnx/venvs"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: create the publishing virtualenv
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name: pip
     virtualenv: "/var/cnx/venvs/publishing"
@@ -94,7 +94,7 @@
 
 - name: install publishing
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     requirements: "/var/lib/cnx/publishing-requirements.txt"
     virtualenv: "/var/cnx/venvs/publishing"


### PR DESCRIPTION
- Add rex variables to the vm environment

  Ansible playbook won't complete without those variables.

- Change /var/cnx/venvs owner to venvs_owner if set

  This is for the vm environment, for development locally, so the ansible
  user can edit the files.
