### PR TITLE
More fixes for the vm environment

### DIFF
--- a/environments/vm/README.md
+++ b/environments/vm/README.md
@@ -21,6 +21,7 @@ ansible-playbook -i environments/vm/inventory configure_hosts.yml
 For provisioning the cnx-suite onto a VM:
 
 ```sh
+rm group_vars/all/vault.yml  # this is not necessary for development
 ansible-playbook -i environments/vm/inventory main.yml
 ```
 

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -51,6 +51,7 @@ accounts_consumer_token:
 accounts_consumer_secret:
 accounts_disable_verify_ssl: yes
 accounts_stub: yes
+# accounts_stub_users is defined in host_vars/local.cnx.org
 
 exercises_token: "somekindoftoken"
 

--- a/environments/vm/host_vars/local.cnx.org
+++ b/environments/vm/host_vars/local.cnx.org
@@ -1,3 +1,6 @@
 ---
 source_dir: /var/lib/cnx
 local_source_dir: "{{ '~/cnx/src' | expanduser }}"
+accounts_stub_users:
+  - "admin,admin"
+  - "moderator,moderator"

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -121,6 +121,16 @@
   with_items:
     - cnx
     - cnx/publishing
+
+- name: check whether repository database is initialized
+  register: repo_db
+  become: yes
+  command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/publishing/app.ini --context cnx-db list"
+  ignore_errors: True
+
+- name: initialize repository database
+  when: "'You may need to create the schema_migrations table' in repo_db.stdout"
+  command: "/bin/true"
   notify:
     - initialize repository database
 

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -47,3 +47,6 @@
     group: root
   notify: restart rsyslog
   tags: rsyslog-conf
+  when:
+    - graylog_server is defined
+    - graylog_port is defined


### PR DESCRIPTION
- Only do "rsyslog : copy CA chain for graylog" if graylog is defined

  There's an encrypted file involved which is not necessary if graylog
  server or port is not defined (e.g. the `vm` environment).

- Define accounts_stub_users in vm host_vars

  This way we can override what's in group_vars/all/ and not use the
  encrypted vault_accounts_stub_users.

- Direct test for when database should be initialized

  Previously we do an indirect test of "if /etc/cnx and
  /etc/cnx/publishing exist", then the database should be initialized as
  well.  It's not robust because the playbook might have failed half way
  creating `/etc/cnx` but not initializing the database.
  
  Use "dbmigrator list" as the test.  It should output a warning message
  to say that the database hasn't been initialized (for migrations at
  least).
