### PR TITLE
Wrap the REX URL mapping in the feature flag check

### DIFF
--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -1,7 +1,9 @@
+{% if rex_redirects_enabled %}
 map $request_uri $rex_uri {
     default "no-match";
     include /etc/nginx/uri-maps/rex-uris.map;
 }
+{% endif %}
 
 server {
     listen          8081;


### PR DESCRIPTION
This wraps the `map` directive. The existing condition is feature flag wrapped, but this was missed.