### PR TITLE
Downgrade tinycss2 from 1.0.2 to 0.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+before_script:
+  # pkg-resources not a package on pypi...
+  # https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command
+  - sed -i '/^pkg-resources==0/ D' environments/__prod_envs/files/*-requirements.txt
+script:
+  # Just testing that everything installs successfully with the right version of python
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then pip install -r environments/__prod_envs/files/archive-requirements.txt; fi
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then pip install -r environments/__prod_envs/files/publishing-requirements.txt; fi
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "3" ]]; then pip install -r environments/__prod_envs/files/press-requirements.txt; fi
+
+notifications:
+  email: false

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -50,7 +50,7 @@ rhaptos.cnxmlutils==1.6.2
 sanction==0.4.1
 six==1.12.0
 SQLAlchemy==1.3.5
-tinycss2==1.0.2
+tinycss2==0.6.1
 translationstring==1.3
 tzlocal==1.5.1
 urllib3==1.25.3


### PR DESCRIPTION
- Add .travis.yml to install prod *-requirements.txt

  Just trying to make sure at least the installation works if nothing
  else...
  
  Use
  `pip install -r environments/__prod_envs/files/archive-requirements.txt`
  etc to check all the packages can be installed successfully.
  
  Also, it looks like `pkg-resources` is something in virtualenv and / or
  ubuntu and Travis can't install it (it's not in pypi).  So removing it
  from the requirements.txt files before running `pip install`.
  
  https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command

- Downgrade tinycss2 from 1.0.2 to 0.6.1

  1.0.2 is not available for python 2 which is what publishing is using.

---

This should ensure we won't have the same problem in the future.  At least everything will install.  Whether the applications will run... is a different problem.