### PR TITLE
Put cnx-db above cnx-archive in archive-requirements.txt

### DIFF
--- a/environments/__dev_envs/files/archive-requirements.txt
+++ b/environments/__dev_envs/files/archive-requirements.txt
@@ -4,8 +4,8 @@ db-migrator==1.1.0
 -e git+https://github.com/openstax/cnx-transforms.git#egg=cnx-transforms
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
--e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
+-e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.3

--- a/environments/vm/files/archive-requirements.txt
+++ b/environments/vm/files/archive-requirements.txt
@@ -4,8 +4,8 @@ db-migrator==1.1.0
 -e git+https://github.com/openstax/cnx-transforms.git#egg=cnx-transforms
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
--e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
+-e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.3


### PR DESCRIPTION
qa.cnx.org is showing an error when starting archive:

```
Traceback (most recent call last):
  File "/var/cnx/venvs/archive/bin/pserve", line 11, in <module>
    sys.exit(main())
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 32, in main
    return command.run()
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 229, in run
    app = loader.get_wsgi_app(app_name, config_vars)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/plaster_pastedeploy/__init__.py", line 131, in get_wsgi_app
    global_conf=defaults)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 271, in loadobj
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 320, in _loadconfig
    return loader.get_context(object_type, name, global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 454, in get_context
    section)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 476, in _context_from_use
    object_type, name=use, global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 406, in get_context
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 328, in _loadegg
    return loader.get_context(object_type, name, global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 620, in get_context
    object_type, name=name)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 640, in find_egg_entry_point
    pkg_resources.require(self.spec)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 891, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (cnx-common 1.1.0 (/var/cnx/venvs/archive/lib/python2.7/site-packages), Requirement.parse('cnx-common>=1.2.1'), set(['cnx-db']))
```

Pip doesn't seem to be able to resolve the versions of the dependencies.
`cnx-archive` needs `cnx-common>=1.1.0` and `cnx-db` needs
`cnx-common>=1.2.1` and `pip install` says:

```
ERROR: cnx-db 3.3.0+6.ga885ed2 has requirement cnx-common>=1.2.1, but you'll have cnx-common 1.1.0 which is incompatible.
```

Putting `cnx-db` on top of `cnx-archive` in requirements.txt seems to
fix this problem... -_-