### PR TITLE
Fixed publishing and archive not starting by force reinstalling dependencies

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -94,7 +94,7 @@
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"
-    state: latest
+    state: forcereinstall
 
 - name: restart archive
   command: "/bin/true"

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -98,7 +98,7 @@
   pip:
     requirements: "/var/lib/cnx/publishing-requirements.txt"
     virtualenv: "/var/cnx/venvs/publishing"
-    state: latest
+    state: forcereinstall
 
 - name: restart publishing
   command: "/bin/true"


### PR DESCRIPTION
Publishing and archive would not start after deployment. There seems to
be an issue with pip installing cnx-common as a dependency. This is a
stop gap solution that will be ultimately fixed by more maintenance work (https://github.com/openstax/cnx/issues/572) that
will resolve this entirely.