### PR TITLE
Downgrade cnx-db from 3.5.0 to 3.4.0

### DIFF
--- a/environments/__prod_envs/files/archive-requirements.txt
+++ b/environments/__prod_envs/files/archive-requirements.txt
@@ -4,7 +4,7 @@ certifi==2019.6.16
 chardet==3.0.4
 cnx-archive==4.13.0
 cnx-common==1.2.2
-cnx-db==3.5.0
+cnx-db==3.4.0
 cnx-epub==0.18.0
 cnx-query-grammar==0.2.2
 cnx-transforms==1.2.0

--- a/environments/__prod_envs/files/press-requirements.txt
+++ b/environments/__prod_envs/files/press-requirements.txt
@@ -4,7 +4,7 @@ bravado-core==5.13.1
 celery==4.3.0
 certifi==2019.6.16
 chardet==3.0.4
-cnx-db==3.5.0
+cnx-db==3.4.0
 cnx-litezip==1.6.0
 cnxml==3.0.1
 gunicorn==19.9.0

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -7,7 +7,7 @@ certifi==2019.6.16
 chardet==3.0.4
 cnx-archive==4.13.0
 cnx-common==1.2.2
-cnx-db==3.5.0
+cnx-db==3.4.0
 cnx-easybake==1.2.5
 cnx-epub==0.18.0
 cnx-publishing==0.17.0


### PR DESCRIPTION
cnx-db 3.5.0 rebakes all the books in the transforms migration but this
is a problem on staging because baking books takes so long and there are
lots of books on the baking queue even after a whole night of
processing.