### PR TITLE
Add travis incompatible package test

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -x
+set -e
+set -o pipefail
+
+PYTHON_MAJOR_VERSION="$(python -c 'import sys; print(sys.version_info.major)')"
+if [[ "${PYTHON_MAJOR_VERSION}" == "2" ]]
+then
+    out=$(pip install -r environments/__prod_envs/files/archive-requirements.txt 2>&1)
+    if echo "$out" | grep -q incompatible
+    then
+        exit 1
+    fi
+    pip uninstall -y -r environments/__prod_envs/files/archive-requirements.txt
+    out=$(pip install -r environments/__prod_envs/files/publishing-requirements.txt 2>&1)
+    if echo "$out" | grep -q incompatible
+    then
+        exit 1
+    fi
+elif [[ "${PYTHON_MAJOR_VERSION}" == "3" ]]
+then
+    out=$(pip install -r environments/__prod_envs/files/press-requirements.txt 2>&1)
+    if echo "$out" | grep -q incompatible
+    then
+        exit 1
+    fi
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ before_script:
   - sed -i '/^pkg-resources==0/ D' environments/__prod_envs/files/*-requirements.txt
 script:
   # Just testing that everything installs successfully with the right version of python
-  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then pip install -r environments/__prod_envs/files/archive-requirements.txt; fi
-  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then pip install -r environments/__prod_envs/files/publishing-requirements.txt; fi
-  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "3" ]]; then pip install -r environments/__prod_envs/files/press-requirements.txt; fi
+  - ./.travis-test.sh
 
 notifications:
   email: false


### PR DESCRIPTION
We had a case where rhaptos.cnxmlutils requires `lxml<4.4` but the
requirements.txt says `lxml==4.4.0`.  `pip install` didn't error so
travis didn't fail, but it did output a message:

```
rhaptos-cnxmlutils 1.7.1 has requirement lxml<4.4,>=4, but you'll have lxml 4.4.0 which is incompatible.
```

This then came up when we tried to start archive:

```
Traceback (most recent call last):
  File "/var/cnx/venvs/archive/bin/pserve", line 10, in <module>
    sys.exit(main())
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 34, in main
    return command.run()
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 275, in run
    app = loader.get_wsgi_app(app_name, config_vars)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/plaster_pastedeploy/__init__.py", line 129, in get_wsgi_app
    global_conf=defaults,
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 253, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 277, in loadobj
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 302, in loadcontext
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 326, in _loadconfig
    return loader.get_context(object_type, name, global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 459, in get_context
    section)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 481, in _context_from_use
    object_type, name=use, global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 412, in get_context
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 302, in loadcontext
    global_conf=global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 334, in _loadegg
    return loader.get_context(object_type, name, global_conf)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 625, in get_context
    object_type, name=name)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 645, in find_egg_entry_point
    pkg_resources.require(self.spec)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 891, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (lxml 4.4.0 (/var/cnx/venvs/archive/lib/python2.7/site-packages), Requirement.parse('lxml<4.4,>=4'), set(['rhaptos.cnxmlutils']))
```

Add a test for "incompatible" in the pip install output so we can catch
this error earlier.