### PR TITLE
Change dev envs to use staging.openstax.org as rex_domain

### DIFF
--- a/environments/autodev01/group_vars/all/vars.yml
+++ b/environments/autodev01/group_vars/all/vars.yml
@@ -71,5 +71,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -76,5 +76,5 @@ nfs_server_for_varnish_logs: dev00.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/easyvm1/group_vars/all/vars.yml
+++ b/environments/easyvm1/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/easyvm2/group_vars/all/vars.yml
+++ b/environments/easyvm2/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/easyvm3/group_vars/all/vars.yml
+++ b/environments/easyvm3/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/easyvm4/group_vars/all/vars.yml
+++ b/environments/easyvm4/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/easyvm5/group_vars/all/vars.yml
+++ b/environments/easyvm5/group_vars/all/vars.yml
@@ -70,5 +70,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/katalyst01/group_vars/all/vars.yml
+++ b/environments/katalyst01/group_vars/all/vars.yml
@@ -68,5 +68,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/legacy-staging/group_vars/all/vars.yml
+++ b/environments/legacy-staging/group_vars/all/vars.yml
@@ -51,5 +51,5 @@ cms_domain: openstax.org
 
 accounts_disable_verify_ssl: yes
 accounts_stub: yes
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -81,5 +81,5 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: true

--- a/environments/tea/group_vars/all/vars.yml
+++ b/environments/tea/group_vars/all/vars.yml
@@ -58,5 +58,5 @@ nfs_server_for_varnish_logs: tea00.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -63,7 +63,7 @@ nfs_server_for_varnish_logs: local.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
+rex_domain: staging.openstax.org
 rex_redirects_enabled: false
 
 venvs_owner: "{{ ansible_user_id }}"


### PR DESCRIPTION
The `rex_domain` setting is used for generating rex redirects using
cnx-rex-redirects script.

rex-web.herokuapp.com doesn't have /rex/environment.json, causing
cnx-rex-redirects to fail.  We are going to just use
staging.openstax.org for all non-prod environments.