### PR TITLE
Stop copying rex-uris.map when rex_redirects_enabled is false

### DIFF
--- a/roles/webview/tasks/webview.yml
+++ b/roles/webview/tasks/webview.yml
@@ -91,7 +91,8 @@
     group: root
     mode: 0755
 
-- name: copy main nginx config
+- name: copy rex-uris.map
+  when: rex_redirects_enabled
   become: yes
   copy:
     src: "{{ inventory_dir }}/files/etc/nginx/uri-maps/rex-uris.map"


### PR DESCRIPTION
There are lots of environments where we probably don't need to have
`rex-uris.map` and have `rex_redirects_enabled` set to false.  The
webview playbook doesn't check for that and always copy `rex-uris.map`
to the server causing this error:

```
TASK [webview : copy main nginx config]
***************************************************************************************************************************************************************************
Wednesday 28 August 2019  09:31:23 -0500 (0:00:00.558)       0:14:17.185
******
An exception occurred during task execution. To see the full traceback,
use -vvv. The error was: If you are using a module and expect the file
to exist on the remote, see the remote_src option
fatal: [content01.cnx.org]: FAILED! => {"changed": false, "msg": "Could
not find or access
'/var/cnx-deploy/environments/content01/files/etc/nginx/uri-maps/rex-uris.map'
on the Ansible Controller.\nIf you are using a module and expect the
file to exist on the remote, see the remote_src option"}
```

Add `when: rex_redirects_enabled` so the file is only copied when
`rex_redirects_enabled` is true.

Also rename the task for copying rex-uris.map from "copy main nginx
config" to "copy rex-uris.map".