### PR TITLE
Enable and set up rex redirects for prod

### DIFF
--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -93,5 +93,5 @@ google_site_verification_filename: "{{ vault_google_site_verification_filename }
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
-rex_domain: rex-web.herokuapp.com
-rex_redirects_enabled: false
+rex_domain: openstax.org
+rex_redirects_enabled: true


### PR DESCRIPTION
Set `rex_domain` to `openstax.org` and `rex_redirects_enabled` to
`true`.

There should be a PR by concourse after this is merged to update the
rex-uris.map.