### PR TITLE
Fix .pyup.yml paths so symlinked files are not updated

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -14,15 +14,15 @@ schedule: "every week on thursday"
 # see https://github.com/pyupio/pyup/issues/360
 # so we need to disable updates to symlinked requirements.txt files
 requirements:
-  - ./environments/prod/files/archive-requirements.txt:
+  - environments/prod/files/archive-requirements.txt:
       update: False
-  - ./environments/prod/files/press-requirements.txt:
+  - environments/prod/files/press-requirements.txt:
       update: False
-  - ./environments/prod/files/publishing-requirements.txt:
+  - environments/prod/files/publishing-requirements.txt:
       update: False
-  - ./environments/staging/files/archive-requirements.txt:
+  - environments/staging/files/archive-requirements.txt:
       update: False
-  - ./environments/staging/files/press-requirements.txt:
+  - environments/staging/files/press-requirements.txt:
       update: False
-  - ./environments/staging/files/publishing-requirements.txt:
+  - environments/staging/files/publishing-requirements.txt:
       update: False


### PR DESCRIPTION
pyup-bot continues to update the symlinked requirements.txt in
`environments/prod/files/` and `environments/staging/files/` in the
weekly update PRs.

The problem is pyup-bot internally uses paths like
`environments/prod/files/archive-requirements.txt` without `./` in
front, so it sees `./environments/prod/files/archive-requirements.txt`
(defined in `.pyup.yml`) as a different file.  So pyup-bot doesn't
update `./environments/prod/files/archive-requirements.txt` but
continues to update `environments/prod/files/archive-requirements.txt`.

The solution here is simply to change all the paths in `.pyup.yml` to
remove the `./` at the beginning.