### PR TITLE
Disable pyup update on tinycss2 for publishing

### DIFF
--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -50,7 +50,7 @@ rhaptos.cnxmlutils==1.7.3
 sanction==0.4.1
 six==1.12.0
 SQLAlchemy==1.3.8
-tinycss2==0.6.1
+tinycss2==0.6.1 # pyup: update no, tinycss2 dropped support for python 2.7
 translationstring==1.3
 tzlocal==2.0.0
 urllib3==1.25.3


### PR DESCRIPTION
tinycss2 removed support for python 2.7 in 1.0.0, pyup-bot is trying to
upgrade tinycss2 to 1.0.2 every week and we have been manually removing
these commits.