### PR TITLE
fix vendor.cnx.org domain for production

### DIFF
--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -43,7 +43,7 @@ accounts_domain: accounts-stage1.openstax.org
 tutor_domain: tutor.openstax.org
 exercises_domain: exercises.openstax.org
 cms_domain: openstax.org
-vendor_domain: vendor-staging.cnx.org
+vendor_domain: vendor.cnx.org
 
 # See group_vars/all.yml for defaults
 graylog_port: 5141


### PR DESCRIPTION
This Ansible lines should differ for production and staging (different domains) and not be the same.

https://github.com/openstax/cnx-deploy/pull/1211/files#diff-f58a1f120274fc9bc5c7571ec112a888R46

https://github.com/openstax/cnx-deploy/pull/1211/files#diff-5621bcde43ce5c90030bc370dab31dceR47