### PR TITLE
support archive proxies for contents and extras routes

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -242,7 +242,7 @@ sub vcl_recv {
         return (pass);
     }
     # cnx rewrite archive - specials served from nginx statically
-    elsif (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml") {
+    elsif (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml" || (req.http.host !~ "^{{ frontend_domain }}" && req.url ~ "^(/contents|/extras)")) {
         if (req.url  == "/robots.txt" || req.url ~ "^/specials") {
             set req.backend_hint = static_files;
         }


### PR DESCRIPTION
this leaves all the existing logic in place, but also uses the archive backend for any requests that _aren't_ on the frontend host (cnx.org) and use the path prefix `/contents` or `/extras`

i have tested this locally with the vagrant vm and it is working, but I'm not sure if there is anything else i need to do to make this change acceptable.

this is the existing behavior on production
![image](https://user-images.githubusercontent.com/636227/76528257-e58e0680-6446-11ea-9ef2-aa7a52b78442.png)


this is with the changes, it supports the other domains and the host header
![image](https://user-images.githubusercontent.com/636227/76526847-90e98c00-6444-11ea-9e70-1594cb2a725b.png)
