### PR TITLE
Modify webview REX redirect map block to use $uri

### DIFF
--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -1,5 +1,5 @@
 {% if rex_redirects_enabled %}
-map $request_uri $rex_uri {
+map $uri $rex_uri {
     default "no-match";
     include /etc/nginx/uri-maps/rex-uris.map;
 }


### PR DESCRIPTION
It was found that redirects did not get mapped as expected when the
request URIs included query parameters. This change is intended to
address this issue by using the $uri variable instead of $request_uri
in the map block as it does not include the query string which we
don't need / use.