### PR TITLE
Upgrade pip explicitly

### DIFF
--- a/roles/cnx_database/tasks/plpython_imports.yml
+++ b/roles/cnx_database/tasks/plpython_imports.yml
@@ -64,6 +64,7 @@
     name: pip
     virtualenv: "/var/cnx/venvs/archive"
     virtualenv_python: python2
+    state: latest
 
 - name: upgrade pip
   become: yes
@@ -78,8 +79,8 @@
   become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name:
-      - setuptools<45
       - distribute
+      - setuptools<45
     virtualenv: "/var/cnx/venvs/archive"
     state: present
 

--- a/roles/cnx_database/tasks/plpython_imports.yml
+++ b/roles/cnx_database/tasks/plpython_imports.yml
@@ -65,13 +65,21 @@
     virtualenv: "/var/cnx/venvs/archive"
     virtualenv_python: python2
 
+- name: upgrade pip
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: pip
+    virtualenv: "/var/cnx/venvs/archive"
+    state: latest
+
 - name: ensure that setuptools<45 is installed
   become: yes
   become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name:
-      - distribute
       - setuptools<45
+      - distribute
     virtualenv: "/var/cnx/venvs/archive"
     state: present
 

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -92,6 +92,14 @@
     - archive
     - publishing
 
+- name: upgrade pip
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: pip
+    virtualenv: "/var/cnx/venvs/publishing"
+    state: latest
+
 - name: ensure that setuptools<45 is installed
   become: yes
   become_user: "{{ venvs_owner|default('www-data') }}"


### PR DESCRIPTION
Currently experiencing an issue where distribute creates an error that pip is out of date. It doesn't appear that when the playbook is running that it follows the playbook exactly. The create virtualenv step uses `state: latest` but doesn't update pip in staging. It does however update when it's run against a local vm. This set of changes explicitly creates a task to upgrade pip. 

```
TASK [cnx_database : ensure that setuptools<45 is installed] *****************************************************************************************************
Monday 30 March 2020  13:16:26 -0500 (0:00:01.939)       0:01:45.809 ********** 
fatal: [staging09.cnx.org]: FAILED! => {"changed": false, "cmd": ["/var/cnx/venvs/archive/bin/pip2", "install", "distribute", "setuptools<45"], "msg": "stdout: Collecting distribute\n  Using cached https://files.pythonhosted.org/packages/5f/ad/1fde06877a8d7d5c9b60eff7de2d452f639916ae1d48f0b8f97bf97e570a/distribute-0.7.3.zip\n    Complete output from command python setup.py egg_info:\n    running egg_info\n    creating pip-egg-info/distribute.egg-info\n    writing requirements to pip-egg-info/distribute.egg-info/requires.txt\n    writing pip-egg-info/distribute.egg-info/PKG-INFO\n    writing top-level names to pip-egg-info/distribute.egg-info/top_level.txt\n    writing dependency_links to pip-egg-info/distribute.egg-info/dependency_links.txt\n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-oVl4lG/distribute/setup.py\", line 58, in <module>\n        setuptools.setup(**setup_params)\n      File \"/usr/lib/python2.7/distutils/core.py\", line 151, in setup\n        dist.run_commands()\n      File \"/usr/lib/python2.7/distutils/dist.py\", line 953, in run_commands\n        self.run_command(cmd)\n      File \"/usr/lib/python2.7/distutils/dist.py\", line 972, in run_command\n        cmd_obj.run()\n      File \"setuptools/command/egg_info.py\", line 177, in run\n        writer = ep.load(installer=installer)\n      File \"pkg_resources.py\", line 2241, in load\n        if require: self.require(env, installer)\n      File \"pkg_resources.py\", line 2254, in require\n        working_set.resolve(self.dist.requires(self.extras),env,installer)))\n      File \"pkg_resources.py\", line 2471, in requires\n        dm = self._dep_map\n      File \"pkg_resources.py\", line 2682, in _dep_map\n        self.__dep_map = self._compute_dependencies()\n      File \"pkg_resources.py\", line 2699, in _compute_dependencies\n        from _markerlib import compile as compile_marker\n    ImportError: No module named _markerlib\n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-oVl4lG/distribute/\nYou are using pip version 9.0.1, however version 20.0.2 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n"}
fatal: [staging10.cnx.org]: FAILED! => {"changed": false, "cmd": ["/var/cnx/venvs/archive/bin/pip2", "install", "distribute", "setuptools<45"], "msg": "stdout: Collecting distribute\n  Using cached https://files.pythonhosted.org/packages/5f/ad/1fde06877a8d7d5c9b60eff7de2d452f639916ae1d48f0b8f97bf97e570a/distribute-0.7.3.zip\n    Complete output from command python setup.py egg_info:\n    running egg_info\n    creating pip-egg-info/distribute.egg-info\n    writing requirements to pip-egg-info/distribute.egg-info/requires.txt\n    writing pip-egg-info/distribute.egg-info/PKG-INFO\n    writing top-level names to pip-egg-info/distribute.egg-info/top_level.txt\n    writing dependency_links to pip-egg-info/distribute.egg-info/dependency_links.txt\n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-6qDEJv/distribute/setup.py\", line 58, in <module>\n        setuptools.setup(**setup_params)\n      File \"/usr/lib/python2.7/distutils/core.py\", line 151, in setup\n        dist.run_commands()\n      File \"/usr/lib/python2.7/distutils/dist.py\", line 953, in run_commands\n        self.run_command(cmd)\n      File \"/usr/lib/python2.7/distutils/dist.py\", line 972, in run_command\n        cmd_obj.run()\n      File \"setuptools/command/egg_info.py\", line 177, in run\n        writer = ep.load(installer=installer)\n      File \"pkg_resources.py\", line 2241, in load\n        if require: self.require(env, installer)\n      File \"pkg_resources.py\", line 2254, in require\n        working_set.resolve(self.dist.requires(self.extras),env,installer)))\n      File \"pkg_resources.py\", line 2471, in requires\n        dm = self._dep_map\n      File \"pkg_resources.py\", line 2682, in _dep_map\n        self.__dep_map = self._compute_dependencies()\n      File \"pkg_resources.py\", line 2699, in _compute_dependencies\n        from _markerlib import compile as compile_marker\n    ImportError: No module named _markerlib\n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-6qDEJv/distribute/\nYou are using pip version 9.0.1, however version 20.0.2 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n"}
```