### PR TITLE
use easy_install to install distribute

### DIFF
--- a/roles/cnx_database/tasks/plpython_imports.yml
+++ b/roles/cnx_database/tasks/plpython_imports.yml
@@ -74,13 +74,19 @@
     virtualenv: "/var/cnx/venvs/archive"
     state: latest
 
+- name: ensure that distribute is installed
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  easy_install:
+    name: distribute
+    virtualenv: "/var/cnx/venvs/archive"
+    state: latest
+
 - name: ensure that setuptools<45 is installed
   become: yes
   become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
-    name:
-      - distribute
-      - setuptools<45
+    name: setuptools<45
     virtualenv: "/var/cnx/venvs/archive"
     state: present
 

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -100,13 +100,19 @@
     virtualenv: "/var/cnx/venvs/publishing"
     state: latest
 
+- name: ensure that distribute is installed
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  easy_install:
+    name: distribute
+    virtualenv: "/var/cnx/venvs/publishing"
+    state: latest
+
 - name: ensure that setuptools<45 is installed
   become: yes
   become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
-    name:
-      - distribute
-      - setuptools<45
+    name: setuptools<45
     virtualenv: "/var/cnx/venvs/publishing"
     state: present
 


### PR DESCRIPTION
Trying out using easy_install instead of pip with reference to this SO
article:
https://stackoverflow.com/questions/35780537/error-no-module-named-markerlib-when-installing-some-packages-on-virtualenv