### PR TITLE
Add vendor condition to varnish

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -242,7 +242,7 @@ sub vcl_recv {
         return (pass);
     }
     # cnx rewrite archive - specials served from nginx statically
-    elsif (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml" || (req.http.host !~ "^{{ frontend_domain }}" && req.url ~ "^(/contents|/extras)")) {
+    elsif (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml" || (req.http.host !~ "^{{ frontend_domain }}"{% if vendor_domain is defined %} && req.http.host !~ "^{{ vendor_domain }}"{% endif %} && req.url ~ "^(/contents|/extras)")) {
         if (req.url  == "/robots.txt" || req.url ~ "^/specials") {
             set req.backend_hint = static_files;
         }


### PR DESCRIPTION
in previous pr https://github.com/openstax/cnx-deploy/pull/1273 forwarding to archive was changed to be done for any hosts that weren't the `frontend_domain`, vs previously it was only done when matching the archive domain.

this didn't take into account `vendor_domain`, which i think is basically a frontend alias, so this adds that to the conditional when it is defined.

my local vm is not provisioning, so i haven't been able to test this locally