### PR TITLE
fix heredoc

### DIFF
--- a/swap_database.yml
+++ b/swap_database.yml
@@ -98,12 +98,13 @@
     - name: rename via pgsql
       become: yes
       become_user: postgres
-      shell: |
-        psql -v ON_ERROR_STOP=1 --username postgres <<-" EOSQL"
-        DROP DATABASE IF EXISTS {{ dest_db_name }};
-        ALTER DATABASE {{ target_db_name }} RENAME TO {{ dest_db_name }};
-        ALTER DATABASE {{ origin_db_name }} RENAME TO {{ target_db_name }};
-        EOSQL
+      shell:
+        cmd: |
+          psql -v ON_ERROR_STOP=1 --username postgres <<-"EOSQL"
+          DROP DATABASE IF EXISTS {{ dest_db_name }};
+          ALTER DATABASE {{ target_db_name }} RENAME TO {{ dest_db_name }};
+          ALTER DATABASE {{ origin_db_name }} RENAME TO {{ target_db_name }};
+          EOSQL
 
 - name: bootstrap replicant
   hosts: replicant


### PR DESCRIPTION
An old way to do heredocs in the shell module was to include a space in the delimiter. That stopped working somewhere between the previous and current versions of Ansible. This PR removes the space and moves the heredoc into the `cmd` argument of the shell module.