### PR TITLE
Archive depend fix

### DIFF
--- a/environments/__prod_envs/vars/versions.yml
+++ b/environments/__prod_envs/vars/versions.yml
@@ -1,2 +1,3 @@
 webview_version: v0.54.0
 press_version: v8.1.7
+archive_version: 4.15.9

--- a/environments/autodev01/group_vars/all/vars.yml
+++ b/environments/autodev01/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content01/group_vars/all/vars.yml
+++ b/environments/content01/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content02/group_vars/all/vars.yml
+++ b/environments/content02/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content03/group_vars/all/vars.yml
+++ b/environments/content03/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content04/group_vars/all/vars.yml
+++ b/environments/content04/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content05/group_vars/all/vars.yml
+++ b/environments/content05/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/content06/group_vars/all/vars.yml
+++ b/environments/content06/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -6,6 +6,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: dev00.cnx.org
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 # FIXME (10-Apr-12017) db-role-perms: assign the role superuser privileges.
 xxx_archive_db_user_role_attr_flags: 'SUPERUSER'
 

--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/easyvm1/group_vars/all/vars.yml
+++ b/environments/easyvm1/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/easyvm2/group_vars/all/vars.yml
+++ b/environments/easyvm2/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/easyvm3/group_vars/all/vars.yml
+++ b/environments/easyvm3/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/easyvm4/group_vars/all/vars.yml
+++ b/environments/easyvm4/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/easyvm5/group_vars/all/vars.yml
+++ b/environments/easyvm5/group_vars/all/vars.yml
@@ -7,6 +7,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/katalyst01/group_vars/all/vars.yml
+++ b/environments/katalyst01/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/legacy-staging/group_vars/all/vars.yml
+++ b/environments/legacy-staging/group_vars/all/vars.yml
@@ -6,6 +6,7 @@ archive_db_user: cnxarchive
 archive_db_password: cnxarchive
 archive_db_host: localhost
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 source:
   # - name:

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -6,6 +6,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: prod09.cnx.org
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: "{{ vault_publishing_broker_user }}"
 publishing_broker_password: "{{ vault_publishing_broker_password }}"

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -6,6 +6,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: staging09.cnx.org
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: "{{ vault_publishing_broker_user }}"
 publishing_broker_password: "{{ vault_publishing_broker_password }}"

--- a/environments/tea/group_vars/all/vars.yml
+++ b/environments/tea/group_vars/all/vars.yml
@@ -6,6 +6,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: tea00.cnx.org
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
+
 
 publishing_broker_user: "{{ vault_publishing_broker_user }}"
 publishing_broker_password: "{{ vault_publishing_broker_password }}"

--- a/environments/vendor-staging01/group_vars/all/vars.yml
+++ b/environments/vendor-staging01/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: "{{ _host_prefix }}.cnx.org"
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/environments/vm/group_vars/all/vars.yml
+++ b/environments/vm/group_vars/all/vars.yml
@@ -6,6 +6,7 @@ archive_db_user: cnxarchive
 archive_db_password: cnxarchive
 archive_db_host: localhost
 archive_db_port: 5432
+archive_pserve_path: /var/cnx/venvs/python2/archive/bin/pserve
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/roles/archive/handlers/main.yml
+++ b/roles/archive/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: add archive 
+  become: yes
+  supervisorctl:
+    name: 'archive:'
+    state: present
 
 - name: restart archive
   become: yes

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -40,6 +40,15 @@
     mode: 0755
     owner: "{{ venvs_owner|default('www-data') }}"
 
+- name: create a new folder for python2 virtualenv 
+  become: yes
+  when: not venvs_dir.stat.exists
+  file:
+    path: "/var/cnx/venvs/python2"
+    state: directory
+    mode: 0755
+    owner: "{{ venvs_owner|default('www-data') }}"
+
 - name: set the owner of venvs directory
   become: yes
   file:
@@ -48,7 +57,7 @@
     recurse: yes
     owner: "{{ venvs_owner|default('www-data') }}"
 
-- name: create the archive virtualenv
+- name: create the archive virtualenv - before migrating to new virtualenv
   become: yes
   become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
@@ -56,6 +65,16 @@
     virtualenv: "/var/cnx/venvs/archive"
     virtualenv_python: python2
     state: latest
+
+- name: create the archive virtualenv - new virtualenv for installing archive
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: pip
+    virtualenv: "/var/cnx/venvs/python2/archive"
+    virtualenv_python: python2
+    state: latest
+
 
 # +++
 # Install
@@ -96,6 +115,34 @@
     virtualenv: "/var/cnx/venvs/archive"
     state: latest
 
+- name: ensure that setuptools<45 is installed in new virtualenv
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: setuptools<45
+    virtualenv: "/var/cnx/venvs/python2/archive"
+    state: present
+
+- name: install archive as a package in new virtualenv
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: cnx-archive
+    version: "{{ archive_version }}|default('latest')"
+    virtualenv: "/var/cnx/venvs/python2/archive"
+    state: present
+
+- name: install new archive virtualenv deploy dependencies
+  become: yes
+  become_user: "{{ venvs_owner|default('www-data') }}"
+  pip:
+    name: "{{ item.key }}"
+    version: "{{ item.value }}"
+    virtualenv: "/var/cnx/venvs/python2/archive"
+    state: present
+  with_dict:
+    - {"pyramid-sawing": 1.1.3}
+
 - name: restart archive
   command: "/bin/true"
   notify:
@@ -133,7 +180,6 @@
 # +++
 # Init service
 # +++
-
 - name: configure archive under supervisor
   become: yes
   template:
@@ -141,7 +187,8 @@
     dest: "/etc/supervisor/conf.d/archive.conf"
     mode: 0644
   notify:
-    - reload supervisord
+    - add archive
+    - restart archive
 
 # +++
 # Cron Configuration

--- a/roles/archive/templates/etc/supervisor/conf.d/archive.conf
+++ b/roles/archive/templates/etc/supervisor/conf.d/archive.conf
@@ -1,6 +1,6 @@
 {% for i in range(0, hostvars[inventory_hostname].archive_count|default(1), 1) %}
 [program:archive{{ i }}]
-command=/var/cnx/venvs/archive/bin/pserve --server-name=instance{{ i }} /etc/cnx/archive/app.ini
+command={{ archive_pserve_path }} --server-name=instance{{ i }} /etc/cnx/archive/app.ini
 
 {% endfor %}
 

--- a/update_versions.yml
+++ b/update_versions.yml
@@ -9,13 +9,13 @@
 - name: get archive versions
   hosts: frontend
   tasks:
-    - shell: /var/cnx/venvs/archive/bin/pip freeze | grep 'cnx-archive'
+    - shell: "$(dirname {{ archive_pserve_path }})/pip freeze | grep 'cnx-archive'"
       register: archive_version
       when: groups.archive
       delegate_to: "{{ item }}"
       with_items:
         - "{{ groups.archive|first }}"
-    - shell: /var/cnx/venvs/archive/bin/pip freeze
+    - shell: "$(dirname {{ archive_pserve_path }})/pip freeze"
       register: archive_full_versions
       when: groups.archive
       delegate_to: "{{ item }}"


### PR DESCRIPTION
In order to fix the dependency issue I've created a new virtualenv where
archive is installed as a package with pip. A separate task will install any
outside dependencies for deployment so that these are more explicit. I
suspect there are some defined in archive-requirements.txt that are not
needed. To facilitate a possible migration to python 3 I've created a
folder in the venv dir for python2 virtualenvs. When we move over we can
remove the old archive venv and leave room open to create a python3 
folder if needed.

* Added task to create a new python2 folder in the venv folder
* Added a task to install archive as a package using pip instead of using the archive-requirements.txt. This allows archive 
  package to control its own dependencies.
* Added a task to ensure setuptools for the new virtualenv is using
  setuptools<45 which causes errors when installing packages in python2
  land.