### PR TITLE
Only one publishing task per child

### DIFF
--- a/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
+++ b/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
@@ -1,7 +1,7 @@
 {% for i in range(0, hostvars[inventory_hostname].publishing_worker_count|default(1), 1) %}
 [program:publishing_celery_worker{{ i }}]
 environment=PYRAMID_INI="/etc/cnx/publishing/app.ini"
-command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing -Q default,deferred
+command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing -Q default,deferred --max-tasks-per-child 1
 user=www-data
 
 {% endfor %}


### PR DESCRIPTION
This should rotate the celery workers for publishing after every task they complete. We only have 1 job type and each is very long-lived, so my concerns doing this are very limited.