### PR TITLE
Add check for AWS credentials file in buildout

### DIFF
--- a/roles/zope_common/tasks/configure_buildout.yml
+++ b/roles/zope_common/tasks/configure_buildout.yml
@@ -14,12 +14,14 @@
     mode: '0640'
   vars:
     dist_cnx_username: >-
-     {{ lookup('aws_secret', dist_cnx_username_secret, region=aws_secrets_region)
-         if (lookup('env', 'AWS_ACCESS_KEY_ID') or lookup('env', 'AWS_PROFILE'))
+      {{ lookup('aws_secret', dist_cnx_username_secret, region=aws_secrets_region)
+         if (lookup('env', 'AWS_ACCESS_KEY_ID') or lookup('env', 'AWS_PROFILE')
+           or lookup('file', '~/.aws/credentials', errors='ignore'))
          else dist_cnx_dev_username|default('') }}
     dist_cnx_password: >-
       {{ lookup('aws_secret', dist_cnx_password_secret, region=aws_secrets_region)
-         if (lookup('env', 'AWS_ACCESS_KEY_ID') or lookup('env', 'AWS_PROFILE'))
+         if (lookup('env', 'AWS_ACCESS_KEY_ID') or lookup('env', 'AWS_PROFILE')
+           or lookup('file', '~/.aws/credentials', errors='ignore'))
          else dist_cnx_dev_password|default('') }}
 
 - name: place the ansible-versions.cfg


### PR DESCRIPTION
In addition to using relevant environment variables to decide whether
to attempt using AWS secrets, add a check for a user credentials file
(e.g. in scenarios like Rundeck where there is a default profile that
can be picked up automatically based on the file).