### PR TITLE
use production exercises for content03

### DIFF
--- a/environments/content03/group_vars/all/vars.yml
+++ b/environments/content03/group_vars/all/vars.yml
@@ -44,7 +44,7 @@ arclishing_domain: "archive-{{ _host_prefix }}.cnx.org"
 frontend_domain: "{{ _host_prefix }}.cnx.org"
 accounts_domain: accounts-qa1.openstax.org
 tutor_domain: tutor-qa.openstax.org
-exercises_domain: exercises-qa.openstax.org
+exercises_domain: exercises.openstax.org
 cms_domain: openstax.org
 
 accounts_disable_verify_ssl: yes


### PR DESCRIPTION
Baking during publishing was failing because exercises-qa did not have the exercise on it.

[Slack context](https://openstax.slack.com/archives/C0LA54Q5C/p1615223823404500)